### PR TITLE
feat: add getInstanceAsync with ready-wait and timeout (S0-95295)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,40 @@ export const getInstance = (
         console.error(error.message);
     });
 
-    
     return unleash;
 };
+
+const DEFAULT_READY_TIMEOUT_MS = 5_000;
+
+export const getInstanceAsync = async (
+    config: ConfigParams,
+    refreshInterval: number = 60_000
+): Promise<Unleash> => {
+    const unleash = getInstance(config, refreshInterval);
+
+    await new Promise<void>(resolve => {
+        if (unleash.isSynchronized()) {
+            console.log("Unleash client already synchronized");
+            resolve();
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            console.warn(
+                "Unleash client not ready after timeout, proceeding with empty cache"
+            );
+            resolve();
+        }, DEFAULT_READY_TIMEOUT_MS);
+
+        unleash.on("ready", () => {
+            clearTimeout(timeout);
+            console.log("Unleash client ready, feature toggles loaded");
+            resolve();
+        });
+    });
+
+    return unleash;
+};
+
+export { Unleash } from "unleash-client";
+export type { ConfigParams };


### PR DESCRIPTION
## Summary

- Adds `getInstanceAsync()` — an async alternative to `getInstance()` that waits for the Unleash client `ready` event with a 5-second timeout before returning, fixing the startup race condition where `isEnabled()` returns `false`
- Maintains full backward compatibility — existing `getInstance()` is unchanged, zero impact on 45+ consuming services
- Mirrors the fix already applied in the Go equivalent (`safe-go-libraries/unleash/unleash.go`)

## Problem

During service startup, `getInstance()` returns immediately before the Unleash client has fetched feature toggles from the server. Any `isEnabled()` call before the `ready` event returns `false`, causing features to be incorrectly disabled on cold starts, deployments, and autoscaling events.

## Solution

New async function `getInstanceAsync()` that:
1. Calls `getInstance()` internally (reuses all existing config)
2. Checks `isSynchronized()` — if already ready, returns immediately
3. Otherwise waits for the `ready` event with a `DEFAULT_READY_TIMEOUT_MS` (5s) timeout
4. On timeout, logs a warning and proceeds with empty cache (fail-open, matching Go behavior)

## Migration

Services can adopt `getInstanceAsync()` at their own pace:

```typescript
// Before (sync, race-prone)
const unleash = getInstance(config);

// After (async, race-safe)
const unleash = await getInstanceAsync(config);
```

## Test plan

- [ ] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Build succeeds (`npm run build`)
- [ ] Prettier formatting clean
- [ ] Verify in a consuming service (reporting-service PoC planned as follow-up)

## References

- Jira: [S0-95295](https://safe-security.atlassian.net/browse/S0-95295)
- Go equivalent fix: `safe-go-libraries/unleash/unleash.go` (`defaultReadyTimeout = 5s`)